### PR TITLE
add trace log configuration for server

### DIFF
--- a/package_.json
+++ b/package_.json
@@ -66,6 +66,17 @@
 					"type": "string",
 					"default": "sk-xxxxxxxxxx",
 					"description": "keides2 の APIキー"
+				},
+				"covlint.trace.server": {
+					"scope": "window",
+					"type": "string",
+					"enum": [
+						"off",
+						"messages",
+						"verbose"
+					],
+					"default": "off",
+					"description": "Traces the communication between VS Code and the language server."
 				}
 			}
 		}


### PR DESCRIPTION
サーバー側のログを表示するかどうか設定する項目を追加します。

デバッグ実行で起動したVSCodeの設定画面(`Ctrl+,`)を開き、
左側から `Extensions` > `covlint` を選び
 `covlint > Trace : Server` で`off` から `verbose` に変更すると有効になります。

デバッグ実行したVSCodeのOutputビューを表示して、右上のプルダウンでcovlint を選べばサーバーのログ出力が確認できるはずです。